### PR TITLE
MCKIN-5311: Add method to calculate course average score.

### DIFF
--- a/social_engagement/tests/test_engagement.py
+++ b/social_engagement/tests/test_engagement.py
@@ -83,6 +83,41 @@ class StudentEngagementTests(ModuleStoreTestCase):
             StudentSocialEngagementScore.generate_leaderboard(self.course.id)
         )
 
+    def test_get_course_average_engagement_score(self):
+        """
+        Verify that average course engagement score is calculated correctly
+        """
+        self.assertEqual(StudentSocialEngagementScore.get_course_average_engagement_score(self.course.id), 0)
+        StudentSocialEngagementScore.save_user_engagement_score(self.course.id, self.user.id, 100)
+        self.assertEqual(StudentSocialEngagementScore.get_course_average_engagement_score(self.course.id), 50)
+        StudentSocialEngagementScore.save_user_engagement_score(self.course.id, self.user2.id, 50)
+        self.assertEqual(StudentSocialEngagementScore.get_course_average_engagement_score(self.course.id), 75)
+        StudentSocialEngagementScore.save_user_engagement_score(self.course.id, self.user2.id, 150)
+        self.assertEqual(StudentSocialEngagementScore.get_course_average_engagement_score(self.course.id), 125)
+
+        # Exclude users from calculation:
+        self.assertEqual(
+            StudentSocialEngagementScore.get_course_average_engagement_score(
+                self.course.id,
+                exclude_users=[self.user.id],
+            ),
+            150
+        )
+        self.assertEqual(
+            StudentSocialEngagementScore.get_course_average_engagement_score(
+                self.course.id,
+                exclude_users=[self.user2.id],
+            ),
+            100
+        )
+        self.assertEqual(
+            StudentSocialEngagementScore.get_course_average_engagement_score(
+                self.course.id,
+                exclude_users=[self.user.id, self.user2.id],
+            ),
+            0
+        )
+
     def test_save_first_engagement_score(self):
         """
         Basic write operation


### PR DESCRIPTION
This patch implements 

```
StudentSocialEngagementScore.get_course_average_engagement_score(course_key, exclude_users=None)
```

 which will be used from the Engagement API.

**JIRA tickets**: MCKIN-5311

**Dependencies**: None

**Testing instructions**:

The easiest way to test this is probably to test it together with the update Engagement API.

**Author notes and concerns**:

Inspiration was taken from https://github.com/edx-solutions/discussion-edx-platform-extensions/pull/9, which implements similar course average calculation, although that one happens inside leaderbord calculation and is not a separate function. The two could probably be consolidate by code from https://github.com/edx-solutions/discussion-edx-platform-extensions/pull/9 using this standalone function.

**Reviewers**
- [x] @bradenmacdonald 