### PR TITLE
added total_user_count to data returned by leaderboard

### DIFF
--- a/social_engagement/models.py
+++ b/social_engagement/models.py
@@ -140,7 +140,7 @@ class StudentSocialEngagementScore(TimeStampedModel):
             queryset = queryset.filter(user__organizations__in=org_ids)
 
         aggregates = queryset.aggregate(Sum('score'))
-        course_avg = 0
+        course_avg = total_user_count = 0
         total_score = aggregates['score__sum'] if aggregates['score__sum'] else 0
         if total_score:
             total_user_count = CourseEnrollment.objects.users_enrolled_in(course_key).exclude(id__in=exclude_users).count()
@@ -155,7 +155,7 @@ class StudentSocialEngagementScore(TimeStampedModel):
                 'score',
                 'modified')\
                 .order_by('-score', 'modified')[:count]
-        return course_avg, queryset
+        return course_avg, total_user_count, queryset
 
 
 class StudentSocialEngagementScoreHistory(TimeStampedModel):

--- a/social_engagement/tests/test_engagement.py
+++ b/social_engagement/tests/test_engagement.py
@@ -159,9 +159,10 @@ class StudentEngagementTests(ModuleStoreTestCase):
         )
 
         # look at the leaderboard
-        course_avg, leaderboard = StudentSocialEngagementScore.generate_leaderboard(self.course.id)
+        course_avg, enrollment_count, leaderboard = StudentSocialEngagementScore.generate_leaderboard(self.course.id)
         self.assertIsNotNone(leaderboard)
         self.assertEqual(len(leaderboard), 1)
+        self.assertEqual(enrollment_count, 2)
         self.assertEqual(course_avg, 5)
 
         self.assertEqual(leaderboard[0]['user__id'], self.user.id)
@@ -209,9 +210,10 @@ class StudentEngagementTests(ModuleStoreTestCase):
         )
 
         # look at the leaderboard
-        course_avg, leaderboard = StudentSocialEngagementScore.generate_leaderboard(self.course.id)
+        course_avg, enrollment_count, leaderboard = StudentSocialEngagementScore.generate_leaderboard(self.course.id)
         self.assertIsNotNone(leaderboard)
         self.assertEqual(len(leaderboard), 1)
+        self.assertEqual(enrollment_count, 2)
         self.assertEqual(course_avg, 10)
 
         self.assertEqual(leaderboard[0]['user__id'], self.user.id)
@@ -354,7 +356,7 @@ class StudentEngagementTests(ModuleStoreTestCase):
             # update whole course and re-calc
             update_course_engagement_scores(self.course.id)
 
-        leaderboard = StudentSocialEngagementScore.generate_leaderboard(self.course.id)
+        course_avg, enrollment_count, leaderboard = StudentSocialEngagementScore.generate_leaderboard(self.course.id)
 
         self.assertEqual(len(leaderboard), 2)
 
@@ -383,11 +385,11 @@ class StudentEngagementTests(ModuleStoreTestCase):
             # update whole course and re-calc
             update_all_courses_engagement_scores()
 
-        course_avg, leaderboard = StudentSocialEngagementScore.generate_leaderboard(self.course.id)
+        course_avg, enrollment_count, leaderboard = StudentSocialEngagementScore.generate_leaderboard(self.course.id)
         self.assertEqual(len(leaderboard), 2)
         self.assertEqual(course_avg, 85)
 
-        course_avg, leaderboard = StudentSocialEngagementScore.generate_leaderboard(course2.id)
+        course_avg, enrollment_count, leaderboard = StudentSocialEngagementScore.generate_leaderboard(course2.id)
         self.assertEqual(len(leaderboard), 1)
         self.assertEqual(course_avg, 85)
 
@@ -422,7 +424,7 @@ class StudentEngagementTests(ModuleStoreTestCase):
             update_all_courses_engagement_scores()
 
             # shouldn't be anything in there because course is closed
-            course_avg, leaderboard = StudentSocialEngagementScore.generate_leaderboard(course2.id)
+            course_avg, enrollment_count, leaderboard = StudentSocialEngagementScore.generate_leaderboard(course2.id)
             self.assertEqual(len(leaderboard), 0)
             self.assertEqual(course_avg, 0)
 
@@ -430,7 +432,7 @@ class StudentEngagementTests(ModuleStoreTestCase):
             update_all_courses_engagement_scores(compute_if_closed_course=True)
 
             # shouldn't be anything in there because course is closed
-            course_avg, leaderboard = StudentSocialEngagementScore.generate_leaderboard(course2.id)
+            course_avg, enrollment_count, leaderboard = StudentSocialEngagementScore.generate_leaderboard(course2.id)
             self.assertEqual(len(leaderboard), 2)
             self.assertEqual(course_avg, 85)
 


### PR DESCRIPTION
This PR has changes to add total enrollments to the tuple returned by `generate_leaderboard` method.
@aamishbaloch could you please review?