### PR TITLE
YONK-864: ability to pull involved users in a question type post

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='discussion-edx-platform-extensions',
-    version='1.1.7',
+    version='1.1.8',
     description='Social engagement management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR has changes to allow retrieval of involved users in a post when it is a question. It would enable us to fix issue reported in [YONK-864](https://openedx.atlassian.net/browse/YONK-864).
@aamishbaloch can you review this?