### PR TITLE
[MCKIN-8714] Fix and secure creating new entries for SocialEngagement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='discussion-edx-platform-extensions',
-    version='1.2.4',
+    version='1.2.5',
     description='Social engagement management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This is a fix for adding new entries.
It also uses `transaction.atomic()` to avoid race conditions.

Testing instructions:
1. Set `ENABLE_SOCIAL_ENGAGEMENT` to `True` in `common.py`.
2. Create new user (or simply clear social entries with `StudentSocialEngagementScore.objects.all().delete()`)
3. Create a thread/post/reply on forum.
4. Check `StudentSocialEngagementScore.objects.last().__dict__` for the score and stats of new user.