### PR TITLE
[REVERT] Bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='discussion-edx-platform-extensions',
-    version='1.2.7',
+    version='1.2.8',
     description='Social engagement management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
As we merged edx-solutions/edx-platform#1273 with this dependency as branch, we need to bump it one version further, as it will not install anymore. We will then use v1.2.8 here: edx-solutions/edx-platform/pull/1275.