### PR TITLE
[YONK-1241] Optimize computing social engagement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='discussion-edx-platform-extensions',
-    version='1.2.9',
+    version='1.2.10',
     description='Social engagement management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',

--- a/social_engagement/handlers.py
+++ b/social_engagement/handlers.py
@@ -16,7 +16,7 @@ from django_comment_common.signals import (
     thread_or_comment_flagged,
 )
 import lms.lib.comment_client as cc
-from social_engagement.tasks import task_handle_change_after_signal
+from social_engagement.tasks import task_update_user_engagement
 
 log = logging.getLogger(__name__)
 
@@ -176,4 +176,4 @@ def _handle_change_after_signal(user_id, course_id, param, increment=True, items
                   `dict[str, int]` (`stat: number_of_occurrences`) with the stats that should be changed
     """
     if settings.FEATURES.get('ENABLE_SOCIAL_ENGAGEMENT') and user_id and course_id:
-        task_handle_change_after_signal.delay(user_id, course_id, param, increment, items)
+        task_update_user_engagement.delay(user_id, course_id, param, increment, items)

--- a/social_engagement/tasks.py
+++ b/social_engagement/tasks.py
@@ -27,18 +27,17 @@ def task_compute_social_scores_in_course(course_id):
     """
     Task to compute social scores in course
     """
-    score_update_count = 0
     course_key = CourseKey.from_string(course_id)
     course = modulestore().get_course(course_key, depth=None)
 
     if course:
-        # For each user compute and save social engagement score
         score_update_count = update_course_engagement(
             course_key, compute_if_closed_course=True, course_descriptor=course
         )
+        log.info("Social scores updated for %d users in course %s", score_update_count or 0, course_id)
+
     else:
         log.info("Course with course id %s does not exist", course_id)
-    log.info("Social scores updated for %d users in course %s", score_update_count, course_id)
 
 
 @task(name=u'lms.djangoapps.social_engagement.tasks.task_update_user_engagement')

--- a/social_engagement/tasks.py
+++ b/social_engagement/tasks.py
@@ -20,23 +20,6 @@ from social_engagement.models import StudentSocialEngagementScore
 log = logging.getLogger('edx.celery.task')
 
 
-@task(name=u'lms.djangoapps.social_engagement.tasks.task_update_user_engagement_score')
-def task_update_user_engagement_score(course_id, user_id):
-    """
-    Task to update user's engagement score
-    """
-    try:
-        update_user_engagement_score(course_id, user_id)
-    except Exception as exc:   # pylint: disable=broad-except
-        log.info(
-            "social engagement score update failure for course {} and user id {} with exception {}".format(
-                course_id,
-                user_id,
-                repr(exc)
-            )
-        )
-
-
 @task(
     name=u'lms.djangoapps.social_engagement.tasks.task_compute_social_scores_in_course',
     routing_key=settings.RECALCULATE_SOCIAL_ENGAGEMENT_ROUTING_KEY,
@@ -65,10 +48,10 @@ def task_compute_social_scores_in_course(course_id):
     log.info("Social scores updated for %d users in course %s", score_update_count, course_id)
 
 
-@task(name=u'lms.djangoapps.social_engagement.tasks.task_handle_change_after_signal')
-def task_handle_change_after_signal(user_id, course_id, param, increment=True, items=1):
+@task(name=u'lms.djangoapps.social_engagement.tasks.task_update_user_engagement')
+def task_update_user_engagement(user_id, course_id, param, increment=True, items=1):
     """
-    Save changes and calculate score.
+    Save changes in stats and calculate score.
 
     :param param: `str` with stat that should be changed or
                   `dict[str, int]` (`stat: number_of_occurrences`) with the stats that should be changed

--- a/social_engagement/tasks.py
+++ b/social_engagement/tasks.py
@@ -5,6 +5,7 @@ import logging
 import pytz
 from datetime import datetime
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db.models import F
 from celery.task import task
@@ -36,7 +37,10 @@ def task_update_user_engagement_score(course_id, user_id):
         )
 
 
-@task(name=u'lms.djangoapps.social_engagement.tasks.task_compute_social_scores_in_course')
+@task(
+    name=u'lms.djangoapps.social_engagement.tasks.task_compute_social_scores_in_course',
+    routing_key=settings.RECALCULATE_SOCIAL_ENGAGEMENT_ROUTING_KEY,
+)
 def task_compute_social_scores_in_course(course_id):
     """
     Task to compute social scores in course


### PR DESCRIPTION
This PR changes default queue for `task_compute_social_scores_in_course` to low-priority queue.