### PR TITLE
no-input support for management command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='discussion-edx-platform-extensions',
-    version='1.2.10',
+    version='1.2.11',
     description='Social engagement management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',

--- a/social_engagement/management/commands/compute_social_engagement_score.py
+++ b/social_engagement/management/commands/compute_social_engagement_score.py
@@ -39,16 +39,32 @@ class Command(BaseCommand):
             help="set this to True if social scores for all open courses needs to be computed",
             metavar="True"
         ),
+        make_option(
+            "--noinput",
+            "--no-input",
+            dest="interactive",
+            action="store_false",
+            default=True,
+            help="Do not prompt the user for input of any kind",
+            metavar="True"
+        ),
     )
 
     def handle(self, *args, **options):
-
         course_id = options.get('course_id')
         compute_for_all_open_courses = options.get('compute_for_all_open_courses')
+        interactive = options.get('interactive')
+
         if course_id:
             task_compute_social_scores_in_course.delay(course_id)
         elif compute_for_all_open_courses:
-            if query_yes_no("Are you sure to compute social engagement scores for all open courses?", default="no"):
+            # prompt for user confirmation in interactive mode
+            execute = query_yes_no(
+                "Are you sure to compute social engagement scores for all open courses?"
+                , default="no"
+            ) if interactive else True
+
+            if execute:
                 open_courses = CourseOverview.objects.filter(
                     Q(end__gte=datetime.datetime.today().replace(tzinfo=UTC)) |
                     Q(end__isnull=True)


### PR DESCRIPTION
no-input can be specified to run **compute_social_engagement_score** in non-interactive mode.

Testing instructions:
1. In default mode, command will require user input
./manage.py lms compute_social_engagement_score -a true --settings=devstack 

2. Running command with `--noinput` will execute without requiring any input
./manage.py lms compute_social_engagement_score -a true --noinput  --settings=devstack
